### PR TITLE
Fix various names (some breaking)

### DIFF
--- a/client.go
+++ b/client.go
@@ -50,7 +50,7 @@ func main() {
 
 	// Get disco#info for home server.
 	info := &DiscoInfo{}
-	iq := xmpp.Iq{Id: xmpp.UUID4(), Type: "get", To: client.JID.Domain}
+	iq := xmpp.IQ{ID: xmpp.UUID4(), Type: "get", To: client.JID.Domain}
 	iq.PayloadEncode(info)
 	reply, _ := client.SendRecv(&iq)
 	reply.PayloadDecode(info)

--- a/src/xmpp/client.go
+++ b/src/xmpp/client.go
@@ -187,29 +187,29 @@ type saslAuth struct {
 
 func bindResource(stream *Stream, jid JID) (JID, error) {
 
-	req := Iq{Id: UUID4(), Type: "set"}
+	req := IQ{ID: UUID4(), Type: "set"}
 	if jid.Resource == "" {
-		req.PayloadEncode(bindIq{})
+		req.PayloadEncode(bindIQ{})
 	} else {
-		req.PayloadEncode(bindIq{Resource: jid.Resource})
+		req.PayloadEncode(bindIQ{Resource: jid.Resource})
 	}
 	if err := stream.Send(req); err != nil {
 		return JID{}, err
 	}
 
-	resp := Iq{}
+	resp := IQ{}
 	err := stream.Decode(&resp, nil)
 	if err != nil {
 		return JID{}, err
 	}
-	bindResp := bindIq{}
+	bindResp := bindIQ{}
 	resp.PayloadDecode(&bindResp)
 
 	boundJID, err := ParseJID(bindResp.JID)
 	return boundJID, nil
 }
 
-type bindIq struct {
+type bindIQ struct {
 	XMLName  xml.Name `xml:"urn:ietf:params:xml:ns:xmpp-bind bind"`
 	Resource string   `xml:"resource,omitempty"`
 	JID      string   `xml:"jid,omitempty"`
@@ -217,13 +217,13 @@ type bindIq struct {
 
 func establishSession(stream *Stream, domain string) error {
 
-	req := Iq{Id: UUID4(), Type: "set", To: domain}
+	req := IQ{ID: UUID4(), Type: "set", To: domain}
 	req.PayloadEncode(&session{})
 	if err := stream.Send(req); err != nil {
 		return err
 	}
 
-	resp := Iq{}
+	resp := IQ{}
 	if err := stream.Decode(&resp, nil); err != nil {
 		return err
 	} else if resp.Error != nil {

--- a/src/xmpp/component.go
+++ b/src/xmpp/component.go
@@ -10,12 +10,12 @@ import (
 // Create a component XMPP connection over the stream.
 func NewComponentXMPP(stream *Stream, jid JID, secret string) (*XMPP, error) {
 
-	streamId, err := startComponent(stream, jid)
+	streamID, err := startComponent(stream, jid)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := handshake(stream, streamId, secret); err != nil {
+	if err := handshake(stream, streamID, secret); err != nil {
 		return nil, err
 	}
 
@@ -33,7 +33,7 @@ func startComponent(stream *Stream, jid JID) (string, error) {
 		},
 	}
 
-	var streamId string
+	var streamID string
 
 	rstart, err := stream.SendStart(&start)
 	if err != nil {
@@ -45,21 +45,21 @@ func startComponent(stream *Stream, jid JID) (string, error) {
 	// Find the stream id.
 	for _, attr := range rstart.Attr {
 		if attr.Name.Local == "id" {
-			streamId = attr.Value
+			streamID = attr.Value
 			break
 		}
 	}
-	if streamId == "" {
+	if streamID == "" {
 		return "", errors.New("Missing stream id")
 	}
 
-	return streamId, nil
+	return streamID, nil
 }
 
-func handshake(stream *Stream, streamId, secret string) error {
+func handshake(stream *Stream, streamID, secret string) error {
 
 	hash := sha1.New()
-	hash.Write([]byte(streamId))
+	hash.Write([]byte(streamID))
 	hash.Write([]byte(secret))
 
 	// Send handshake.

--- a/src/xmpp/disco.go
+++ b/src/xmpp/disco.go
@@ -16,7 +16,7 @@ type Disco struct {
 	XMPP *XMPP
 }
 
-// Iq get/result payload for "info" requests.
+// IQ get/result payload for "info" requests.
 type DiscoInfo struct {
 	XMLName  xml.Name        `xml:"http://jabber.org/protocol/disco#info query"`
 	Node     string          `xml:"node,attr"`
@@ -36,7 +36,7 @@ type DiscoFeature struct {
 	Var string `xml:"var,attr"`
 }
 
-// Iq get/result payload for "items" requests.
+// IQ get/result payload for "items" requests.
 type DiscoItems struct {
 	XMLName xml.Name    `xml:"http://jabber.org/protocol/disco#items query"`
 	Node    string      `xml:"node,attr"`
@@ -57,7 +57,7 @@ func (disco *Disco) Info(to, from string) (*DiscoInfo, error) {
 		from = disco.XMPP.JID.Full()
 	}
 
-	req := &Iq{Id: UUID4(), Type: IQTypeGet, To: to, From: from}
+	req := &IQ{ID: UUID4(), Type: IQTypeGet, To: to, From: from}
 	req.PayloadEncode(&DiscoInfo{})
 
 	resp, err := disco.XMPP.SendRecv(req)
@@ -80,7 +80,7 @@ func (disco *Disco) Items(to, from, node string) (*DiscoItems, error) {
 		from = disco.XMPP.JID.Full()
 	}
 
-	req := &Iq{Id: UUID4(), Type: IQTypeGet, To: to, From: from}
+	req := &IQ{ID: UUID4(), Type: IQTypeGet, To: to, From: from}
 	req.PayloadEncode(&DiscoItems{Node: node})
 
 	resp, err := disco.XMPP.SendRecv(req)
@@ -101,7 +101,7 @@ var discoNamespacePrefix = strings.Split(NSDiscoInfo, "#")[0]
 // Matcher instance to match <iq/> stanzas with a disco payload.
 var DiscoPayloadMatcher = MatcherFunc(
 	func(v interface{}) bool {
-		iq, ok := v.(*Iq)
+		iq, ok := v.(*IQ)
 		if !ok {
 			return false
 		}

--- a/src/xmpp/dns.go
+++ b/src/xmpp/dns.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	// Standard port for XMPP clients to connect to.
-	XMPP_CLIENT_PORT = 5222
+	ClientPort = 5222
 )
 
 // Perform a DNS SRV lookup and return an ordered list of "host:port" TCP
@@ -22,7 +22,7 @@ func HomeServerAddrs(jid JID) (addr []string, err error) {
 	// If there's nothing in DNS then assume the JID's domain and the standard
 	// port will work.
 	if len(addrs) == 0 {
-		addr = []string{fmt.Sprintf("%s:%d", jid.Domain, XMPP_CLIENT_PORT)}
+		addr = []string{fmt.Sprintf("%s:%d", jid.Domain, ClientPort)}
 		return
 	}
 

--- a/src/xmpp/doc.go
+++ b/src/xmpp/doc.go
@@ -33,7 +33,7 @@ shutdown or any other error for something unexpected). The channel is also
 closed after an error.
 
 XMPP defines four types of stanza: <error/>, <iq/>, <message/> and <presence/>
-represented by Error, Iq, Message (shown below) and Presence structs
+represented by Error, IQ, Message (shown below) and Presence structs
 respectively.
 
 	for i := range X.In {

--- a/src/xmpp/httpAuth.go
+++ b/src/xmpp/httpAuth.go
@@ -11,7 +11,7 @@ const (
 // XEP-0070: Verifying HTTP Requests via XMPP
 type Confirm struct {
 	XMLName xml.Name `xml:"http://jabber.org/protocol/http-auth confirm"`
-	Id      string   `xml:"id,attr"`
+	ID      string   `xml:"id,attr"`
 	Method  string   `xml:"method,attr"`
 	URL     string   `xml:"url,attr"`
 }

--- a/src/xmpp/stanza.go
+++ b/src/xmpp/stanza.go
@@ -18,9 +18,9 @@ const (
 )
 
 // XMPP <iq/> stanza.
-type Iq struct {
+type IQ struct {
 	XMLName xml.Name `xml:"iq"`
-	Id      string   `xml:"id,attr"`
+	ID      string   `xml:"id,attr"`
 	Type    string   `xml:"type,attr"`
 	To      string   `xml:"to,attr,omitempty"`
 	From    string   `xml:"from,attr,omitempty"`
@@ -30,7 +30,7 @@ type Iq struct {
 
 // Encode the value to an XML string and set as the payload. See xml.Marshal
 // for how the value is encoded.
-func (iq *Iq) PayloadEncode(v interface{}) error {
+func (iq *IQ) PayloadEncode(v interface{}) error {
 	bytes, err := xml.Marshal(v)
 	if err != nil {
 		return err
@@ -41,12 +41,12 @@ func (iq *Iq) PayloadEncode(v interface{}) error {
 
 // Decode the payload (an XML string) into the given value. See xml.Unmarshal
 // for how the value is decoded.
-func (iq *Iq) PayloadDecode(v interface{}) error {
+func (iq *IQ) PayloadDecode(v interface{}) error {
 	return xml.Unmarshal([]byte(iq.Payload), v)
 }
 
 // Return the name of the payload element.
-func (iq *Iq) PayloadName() (name xml.Name) {
+func (iq *IQ) PayloadName() (name xml.Name) {
 	dec := xml.NewDecoder(bytes.NewBufferString(iq.Payload))
 	tok, err := dec.Token()
 	if err != nil {
@@ -59,16 +59,16 @@ func (iq *Iq) PayloadName() (name xml.Name) {
 	return start.Name
 }
 
-// Create a response Iq. The Id is kept, To and From are reversed, Type is set
+// Create a response IQ. The ID is kept, To and From are reversed, Type is set
 // to the given value.
-func (iq *Iq) Response(type_ string) *Iq {
-	return &Iq{Id: iq.Id, Type: type_, From: iq.To, To: iq.From}
+func (iq *IQ) Response(iqType string) *IQ {
+	return &IQ{ID: iq.ID, Type: iqType, From: iq.To, To: iq.From}
 }
 
 // XMPP <message/> stanza.
 type Message struct {
 	XMLName xml.Name      `xml:"message"`
-	Id      string        `xml:"id,attr,omitempty"`
+	ID      string        `xml:"id,attr,omitempty"`
 	Type    string        `xml:"type,attr,omitempty"`
 	To      string        `xml:"to,attr,omitempty"`
 	From    string        `xml:"from,attr,omitempty"`
@@ -95,7 +95,7 @@ type MessageBody struct {
 // XMPP <presence/> stanza.
 type Presence struct {
 	XMLName xml.Name `xml:"presence"`
-	Id      string   `xml:"id,attr,omitempty"`
+	ID      string   `xml:"id,attr,omitempty"`
 	Type    string   `xml:"type,attr,omitempty"`
 	To      string   `xml:"to,attr,omitempty"`
 	From    string   `xml:"from,attr,omitempty"`


### PR DESCRIPTION
Some breaking name changes:

- FilterId -> FilterID
- Id -> ID (various struct types)
- Iq -> IQ and IqResult -> IQResult
- XMPP_CLIENT_PORT -> ClientPort

And a few related, non-breaking cleanups:

- bindIq -> bindIQ
- streamId -> streamID
- nextFilterId -> nextFilterID

Note: depends on https://github.com/emgee/go-xmpp/pull/8 (Lint Cleanup)